### PR TITLE
Make `flash`-messages full screen on desktop

### DIFF
--- a/rails/app/views/shared/_flash.html.erb
+++ b/rails/app/views/shared/_flash.html.erb
@@ -1,5 +1,5 @@
 <% if alert = flash.alert %>
-  <div class="max-w-3xl my-4 sm:my-6 mx-auto px-4 sm:px-6">
+  <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 my-4 sm:my-6">
     <div class="rounded-md bg-red-50 p-4">
       <div class="flex">
         <div class="flex-shrink-0">
@@ -14,7 +14,7 @@
 <% end %>
 
 <% if notice = flash.notice %>
-  <div class="max-w-3xl my-4 sm:my-6 mx-auto px-4 sm:px-6">
+  <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 my-4 sm:my-6">
     <div class="rounded-md bg-green-50 p-4">
       <div class="flex">
         <div class="flex-shrink-0">


### PR DESCRIPTION
Hello (again! - I swear this is my last pr for today 😇☺️)

This might be a matter of taste but the full screen messages (like they appear on mobile) look a lot nicer to my eyes 👀😁.

👨‍⚖️ **You be the judge!**

# Before

<img width="1822" alt="Screenshot 2023-12-17 at 13 39 50" src="https://github.com/joemasilotti/daily-log/assets/425211/4c12accd-7665-457c-a631-9a6f8e9607fe">

# After

<img width="1254" alt="Screenshot 2023-12-21 at 11 48 56" src="https://github.com/joemasilotti/daily-log/assets/425211/02546ce1-7b46-4f02-ace4-ffb9a9e91700">
