### PR TITLE
Update form_helper.rb

### DIFF
--- a/rails/app/helpers/form_helper.rb
+++ b/rails/app/helpers/form_helper.rb
@@ -11,8 +11,7 @@ module FormHelper
   def strada_form_with(*, **options, &block)
     options[:html] ||= {}
     options[:html][:data] ||= {}
-    options[:html][:data] = options[:html][:data].merge(strada_form_data)
-
+    options[:html][:data] = options[:html][:data].merge(strada_form_data(options))
     options[:builder] = StradaFormBuilder
 
     form_with(*, **options, &block)
@@ -20,9 +19,15 @@ module FormHelper
 
   private
 
-  def strada_form_data
+  def strada_form_data(options)
+    if options[:data].key?(:controller)
+      controllers = options[:data][:controller].split(" ")
+    else
+      controllers = []
+    end
+
     {
-      controller: "bridge--form",
+      controller: (controllers + ["bridge--form"]).join(" "),
       action: "turbo:submit-start->bridge--form#submitStart turbo:submit-end->bridge--form#submitEnd"
     }
   end


### PR DESCRIPTION
If the form has other stimulus controllers then they get overwritten by the strada_form_with helper. This change will merge them together. e.g.

```
    <%= strada_form_with(
      model: person,
      data: {
        controller: "person",
```

I thought I would submit this change here in case others are using this for inspiration like I did.