### PR TITLE
fallback to local path-configuration file

### DIFF
--- a/ios/App/Configuration/path-configuration.json
+++ b/ios/App/Configuration/path-configuration.json
@@ -1,0 +1,21 @@
+{
+  "settings": {},
+  "rules": [
+    {
+      "patterns": ["/recede_historical_location"],
+      "properties": {
+        "presentation": "pop"
+      }
+    },
+    {
+      "patterns": [
+        "/new$",
+        "/edit$",
+        "/settings"
+      ],
+      "properties": {
+        "context": "modal"
+      }
+    }
+  ]
+}

--- a/ios/App/Delegates/SceneDelegate.swift
+++ b/ios/App/Delegates/SceneDelegate.swift
@@ -6,6 +6,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     private lazy var navigator = TurboNavigator(pathConfiguration: pathConfiguration, delegate: self)
     private let pathConfiguration = PathConfiguration(sources: [
+        .file(Bundle.main.url(forResource: "path-configuration", withExtension: "json")!),
         .server(Endpoint.pathConfigurationURL)
     ])
 

--- a/ios/DailyLog.xcodeproj/project.pbxproj
+++ b/ios/DailyLog.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		4EFBF2932C3FBC8B00A9A01B /* path-configuration.json in Resources */ = {isa = PBXBuildFile; fileRef = 4EFBF2922C3FBC8B00A9A01B /* path-configuration.json */; };
 		842525C62B2788BA00DB6CD3 /* ButtonComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 842525C52B2788BA00DB6CD3 /* ButtonComponent.swift */; };
 		84A23A2B2B2364DA00654CDF /* FormComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84A23A2A2B2364DA00654CDF /* FormComponent.swift */; };
 		84C3CE692B216CD40036700C /* WebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84C3CE682B216CD40036700C /* WebViewController.swift */; };
@@ -25,6 +26,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		4EFBF2922C3FBC8B00A9A01B /* path-configuration.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "path-configuration.json"; sourceTree = "<group>"; };
 		842525C52B2788BA00DB6CD3 /* ButtonComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonComponent.swift; sourceTree = "<group>"; };
 		84A23A2A2B2364DA00654CDF /* FormComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormComponent.swift; sourceTree = "<group>"; };
 		84C3CE682B216CD40036700C /* WebViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewController.swift; sourceTree = "<group>"; };
@@ -143,6 +145,7 @@
 		84DE93BC2B205223006BDECB /* Configuration */ = {
 			isa = PBXGroup;
 			children = (
+				4EFBF2922C3FBC8B00A9A01B /* path-configuration.json */,
 				84DE93BD2B205228006BDECB /* Endpoint.swift */,
 			);
 			path = Configuration;
@@ -215,6 +218,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				84DE93AD2B202F63006BDECB /* LaunchScreen.storyboard in Resources */,
+				4EFBF2932C3FBC8B00A9A01B /* path-configuration.json in Resources */,
 				84DE93AA2B202F63006BDECB /* Assets.xcassets in Resources */,
 				84DE93A82B202F62006BDECB /* Main.storyboard in Resources */,
 			);


### PR DESCRIPTION
https://github.com/joemasilotti/daily-log/issues/15

> Always include local path configuration. Turbo Native will fall back to the local version if downloading remote path configuration fails.
- https://masilotti.com/turbo-native-path-configuration/